### PR TITLE
Included Refresh Tokens & Updated README.md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,37 @@
 
 Built using the [*Spring Framework*](https://spring.io/) (Java) and [*React*](https://react.dev/) (TypeScript), it is my personal flagship project that I made to showcase my full-stack development skills.
 
-# Technologies
+# Overview of Technologies
+The following table contains more general technologies that apply to the application as a whole rather than being more related to either back-end or front-end servers:
 
 | Technology | Description |
 |--- |--- |
-| [**Spring Framework**](https://spring.io/) | Used for the [back-end server](./spring). |
-| [**React**](https://react.dev/) | Used for the front-end server. |
-| [**Tailwind CSS**](https://tailwindcss.com/) | CSS utility classes primarily used on markup. |
-| [**Hibernate**](https://hibernate.org/) | object-relational mapping (ORM) tool of choice to ease the creation of the database. |
-| [**MySQL**](https://www.mysql.com/) | Used for the database |
 | [**Docker**](https://www.docker.com/) | used to create images and containers for the needed servers. |
 | [**Jenkins**](https://www.jenkins.io/) | used to automate the entire build process. |
+
+Here is a brief list of technologies used for the [back-end server](./spring). If you want more details regarding the back-end server, please read the [`README.md`](./spring/README.md) file in the `./spring` directory.
+| Back-end Technology | Description |
+|--- |--- |
+| [**Spring Framework**](https://spring.io/) | Main back-end framework of choice. Chosen to primarily demonstrate my existing skills in [Java](https://www.java.com/en/). |
+| [**MySQL**](https://www.mysql.com/) | Database of choice. Could've easily chosen [PostgreSQL](https://www.postgresql.org/) |
+| [**Hibernate**](https://hibernate.org/) | object-relational mapping (ORM) tool of choice to ease the creation of the database, as well as ensuring the mocked database has the same structure as the main database. |
+| [**Testcontainers**](https://testcontainers.com/) | Used to mock the MySQL database for testing purposes. |
+| [**Mockito**](https://site.mockito.org/) | Used to mock specific services that application uses |
+
+Here is a brief list of technologies used for the [front-end server](./react). If you want more details regarding the front-end server, please read the [`README.md`](./react/README.md) file in the `./react` directory.
+
+| Front-end Technology | Description |
+|--- |--- |
+| [**React**](https://react.dev/) | Used for the front-end server. [TypeScript](https://www.typescriptlang.org/) is used to here. |
+| [**Tailwind CSS**](https://tailwindcss.com/) | contains common CSS utility classes that are agnostic to the overall structure of the application. |
 
 # Building from Source
 There are multiple ways to build this application from source code:
 
 * Using [**Jenkins**](https://www.jenkins.io/) to automate the build (**recommended**) - see [`./resources/docs/BUILD_USING_JENKINS.md`](resources/docs/BUILD_USING_JENKINS.md) for more information.
 
-* Using [**Docker**](https://www.docker.com/) & *Docker Compose* to build the application - see [`./resources/docs/BUILD_USING_DOCKER.md`](resources/docs/BUILD_USING_DOCKER.md) for more information.
+* Using [**Docker**](https://www.docker.com/) to build the application - see [`./resources/docs/BUILD_USING_DOCKER.md`](resources/docs/BUILD_USING_DOCKER.md) for more information.
+
 
 # License
-
 Focust is licensed under the **[GNU General Public License v3.0](LICENSE)**. To learn more, go to *https://www.gnu.org/licenses/*

--- a/spring/README.md
+++ b/spring/README.md
@@ -18,7 +18,7 @@ The Spring application uses *Java JDK 23*.
 | [**Testcontainers**](https://testcontainers.com/) | `1.19.8`[^1] | Used to create a lightweight MySQL database for testing purposes. |
 | **MySQL JDBC Driver** | `8.3.0`[^1] | Allows the server to interact with the MySQL database. |
 | [**JGit**](https://github.com/eclipse-jgit/jgit) | `7.0.0.202409031743-r` | Allows the application to interact with [git](https://git-scm.com/). |
-| [**JUnit**](https://junit.org/junit5/) | `4.13.2`[^2] | Used to create (unit) tests in Java. Includes [JUnit Jupiter]() |
+| [**JUnit 5**](https://junit.org/junit5/) | `4.13.2`[^2] | Used to create (unit) tests in Java. Includes [JUnit Jupiter]() |
 | [**Mockito**](https://site.mockito.org/) | `5.11.0`[^2] | Used to easily create mocks for testing. |
 | [**Auth0 Java-JWT**](https://github.com/auth0/java-jwt) | `4.4.0` | Used to create, sign, and verify JWT tokens. |
 | [**REST-Assured**](https://rest-assured.io/) | `5.5.0` | Used to interact with server endpoints when testing. |

--- a/spring/src/main/java/com/focust/api/dto/requests/PageNumberRequest.java
+++ b/spring/src/main/java/com/focust/api/dto/requests/PageNumberRequest.java
@@ -1,5 +1,5 @@
 /**
- * PageNumberRequest.java - Request for
+ * PageNumberRequest.java - Request for the number of pages of entries of a table
  * Copyright (C) 2024  Allan DeBoe
  *
  * This program is free software: you can redistribute it and/or modify
@@ -16,11 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * ------------------------------------------------------------------------
  *
- * @see com.focust.api.users.User
- * @see com.focust.api.controllers.UserController
- *
  * @author Allan DeBoe (allan.m.deboe@gmail.com)
- * @version 0.0.3
+ * @version 0.0.4
  * @since 0.0.3
  */
 package com.focust.api.dto.requests;
@@ -40,7 +37,7 @@ public final class PageNumberRequest implements Request {
     private int pageNumber = 1;
 
     @Override
-    public String getJSON() {
+    public String getJson() {
         return "{ \"pageNumber\": " + pageNumber + " }";
     }
 

--- a/spring/src/main/java/com/focust/api/dto/requests/RegisterUserRequest.java
+++ b/spring/src/main/java/com/focust/api/dto/requests/RegisterUserRequest.java
@@ -19,7 +19,7 @@
  * @see com.focust.api.users.User
  *
  * @author Allan DeBoe (allan.m.deboe@gmail.com)
- * @version 0.0.3
+ * @version 0.0.4
  * @since 0.0.3
  */
 package com.focust.api.dto.requests;
@@ -39,7 +39,7 @@ public final class RegisterUserRequest implements Request {
     @Getter private final String password;
 
     @Override
-    public String getJSON() {
+    public String getJson() {
         return "{ \"email\": \"" + this.email + "\", \"password\": \"" + this.password + "\" }";
     }
 }

--- a/spring/src/main/java/com/focust/api/dto/requests/Request.java
+++ b/spring/src/main/java/com/focust/api/dto/requests/Request.java
@@ -1,7 +1,29 @@
+/**
+ * Request.java - Interface used for Requests
+ * Copyright (C) 2024  Allan DeBoe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * ------------------------------------------------------------------------
+ *
+ * @author Allan DeBoe (allan.m.deboe@gmail.com)
+ * @version 0.0.3
+ * @since 0.0.3
+ */
 package com.focust.api.dto.requests;
 
 public interface Request {
 
-    public String getJSON();
+    public String getJson();
 
 }

--- a/spring/src/main/java/com/focust/api/dto/requests/SignInUserRequest.java
+++ b/spring/src/main/java/com/focust/api/dto/requests/SignInUserRequest.java
@@ -19,7 +19,7 @@
  * @see com.focust.api.users.User
  *
  * @author Allan DeBoe (allan.m.deboe@gmail.com)
- * @version 0.0.3
+ * @version 0.0.4
  * @since 0.0.3
  */
 package com.focust.api.dto.requests;
@@ -40,7 +40,7 @@ public final class SignInUserRequest implements Request {
     private final String password;
 
     @Override
-    public String getJSON() {
+    public String getJson() {
         return "{ \"email\": \"" + this.email + "\", \"password\": \"" + this.password + "\" }";
     }
 }

--- a/spring/src/main/java/com/focust/api/dto/responses/JwtTokenResponse.java
+++ b/spring/src/main/java/com/focust/api/dto/responses/JwtTokenResponse.java
@@ -1,5 +1,5 @@
 /**
- * JWTAccessTokenResponse.java - DTO Response containing just a JWT Access Token
+ * JwtAccessTokenResponse.java - DTO Response containing just a JWT Access Token
  * Copyright (C) 2024  Allan DeBoe
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,11 +20,11 @@
  * which merely contains a JWT Token that the client is meant to store
  * for later.
  *
- * @see com.focust.api.security.jwt.JWTService
+ * @see com.focust.api.security.jwt.JwtService
  * @see com.focust.api.controllers.AuthenticationController
  *
  * @author Allan DeBoe (allan.m.deboe@gmail.com)
- * @version 0.0.3
+ * @version 0.0.4
  * @since 0.0.3
  */
 package com.focust.api.dto.responses;
@@ -35,15 +35,14 @@ package com.focust.api.dto.responses;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
 ///////////////////////////////////////////////////////////////////////////
 
 @RequiredArgsConstructor
 @AllArgsConstructor
-public final class JWTAccessTokenResponse {
+public final class JwtTokenResponse {
 
-    @Getter private final String jwtToken;
+    @Getter private final String accessToken;
     @Getter private long userId;
 
 }

--- a/spring/src/main/java/com/focust/api/exceptions/EmptyPageException.java
+++ b/spring/src/main/java/com/focust/api/exceptions/EmptyPageException.java
@@ -19,11 +19,11 @@
  * @see org.springframework.data.domain.Page
  *
  * @author Allan DeBoe (allan.m.deboe@gmail.com)
- * @version 0.0.3
+ * @version 0.0.4
  * @since 0.0.3
  */
 package com.focust.api.exceptions;
 
 ///////////////////////////////////////////////////////////////////////////
 
-public class EmptyPageException extends RuntimeException { }
+public final class EmptyPageException extends RuntimeException { }

--- a/spring/src/main/java/com/focust/api/security/SecurityConfiguration.java
+++ b/spring/src/main/java/com/focust/api/security/SecurityConfiguration.java
@@ -17,7 +17,7 @@
  * ------------------------------------------------------------------------
  *
  * @author Allan DeBoe (allan.m.deboe@gmail.com)
- * @version 0.0.3
+ * @version 0.0.4
  * @since 0.0.2
  */
 package com.focust.api.security;
@@ -25,12 +25,10 @@ package com.focust.api.security;
 ///////////////////////////////////////////////////////////////////////////
 
 // Focust //
-import com.focust.api.security.jwt.JWTAuthenticationFilter;
+import com.focust.api.security.jwt.JwtAuthenticationFilter;
 
 // Spring Framework //
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.ssl.SslBundles;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -39,12 +37,9 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 // Standard Java //
 import java.util.Arrays;
@@ -59,7 +54,7 @@ public class SecurityConfiguration {
     private Environment environment;
 
     @Autowired
-    private JWTAuthenticationFilter jwtAuthenticationFilter;
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     CorsConfigurationSource corsConfigurationSource() {

--- a/spring/src/main/java/com/focust/api/security/jwt/JwtAuthenticationFilter.java
+++ b/spring/src/main/java/com/focust/api/security/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,5 @@
 /**
- * JWTAuthenticationFilter.java - Used to check if a request has a valid JWT token.
+ * JwtAuthenticationFilter.java - Used to check if a request has a valid JWT token.
  * Copyright (C) 2024  Allan DeBoe
  *
  * This program is free software: you can redistribute it and/or modify
@@ -17,7 +17,7 @@
  * ------------------------------------------------------------------------
  *
  * @author Allan DeBoe (allan.m.deboe@gmail.com)
- * @version 0.0.3
+ * @version 0.0.4
  * @since 0.0.3
  */
 
@@ -27,7 +27,7 @@ package com.focust.api.security.jwt;
 
 // Focust //
 import com.focust.api.exceptions.UserNotFoundException;
-import com.focust.api.users.UserJWTDetails;
+import com.focust.api.users.UserJwtDetails;
 import com.focust.api.users.UserService;
 
 // Jakarta Servlets //
@@ -55,9 +55,9 @@ import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
-public class JWTAuthenticationFilter extends OncePerRequestFilter {
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    @Autowired private JWTService jwtService;
+    @Autowired private JwtService jwtService;
     @Autowired private UserService userService;
 
     @Override
@@ -83,7 +83,7 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
 
         try {
             String email = jwtService.getEmail(jwtToken.get()).orElseThrow(Exception::new);
-            UserJWTDetails jwtDetails = userService.getUserDetails(email);
+            UserJwtDetails jwtDetails = userService.getUserDetails(email);
         }
 
         // "NoSuchAlgorithmException" and "InvalidKeySpecException" are thrown as a

--- a/spring/src/main/java/com/focust/api/users/UserJwtDetails.java
+++ b/spring/src/main/java/com/focust/api/users/UserJwtDetails.java
@@ -1,5 +1,5 @@
 /**
- * UserJWTDetails.java - used to create JWT tokens off of user details.
+ * UserJwtDetails.java - used to create JWT tokens off of user details.
  * Copyright (C) 2024  Allan DeBoe
  *
  * This program is free software: you can redistribute it and/or modify
@@ -19,10 +19,10 @@
  * This immutable, data class merely exists
  *
  * @see com.focust.api.users.User
- * @see com.focust.api.security.jwt.JWTService
+ * @see com.focust.api.security.jwt.JwtService
  *
  * @author Allan DeBoe (allan.m.deboe@gmail.com)
- * @version 0.0.3
+ * @version 0.0.4
  * @since 0.0.3
  */
 package com.focust.api.users;
@@ -35,12 +35,12 @@ import lombok.Getter;
 ///////////////////////////////////////////////////////////////////////////
 
 @Getter
-public final class UserJWTDetails {
+public final class UserJwtDetails {
 
     private final long id;
     private final String email;
 
-    UserJWTDetails(User user) {
+    UserJwtDetails(User user) {
         this.id = user.getId();
         this.email = user.getEmail();
     }

--- a/spring/src/main/java/com/focust/api/users/UserService.java
+++ b/spring/src/main/java/com/focust/api/users/UserService.java
@@ -22,7 +22,7 @@
  * @see com.focust.api.users.User
  *
  * @author Allan DeBoe (allan.m.deboe@gmail.com)
- * @version 0.0.3
+ * @version 0.0.4
  * @since 0.0.3
  */
 package com.focust.api.users;
@@ -41,6 +41,8 @@ import com.focust.api.exceptions.UserNotFoundException;
 import com.focust.api.security.bcrypt.BCryptHash;
 
 // Spring Framework //
+import com.focust.api.security.jwt.JwtAuthenticationFilter;
+import com.focust.api.security.jwt.JwtService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -68,37 +70,37 @@ public class UserService {
      * associated with the user. Emails are essentially usernames
      * in the context of the application, hence why this exists.
      *
-     * @see com.focust.api.security.jwt.JWTService
-     * @see com.focust.api.security.jwt.JWTAuthenticationFilter
+     * @see JwtService
+     * @see JwtAuthenticationFilter
      *
      * @param email the email of the user
      * @return a UserJWTDetails object based on the user with the email
      * @throws UserNotFoundException if the user with the email is not found
      */
-    public final UserJWTDetails getUserDetails(String email) throws UserNotFoundException {
+    public final UserJwtDetails getUserDetails(String email) throws UserNotFoundException {
         User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
-        return new UserJWTDetails(user);
+        return new UserJwtDetails(user);
     }
 
     /**
      * This function is used when verifying a user log in, to which,
      * if the login is successful, a JWT Token gets returned.
      *
-     * @see com.focust.api.security.jwt.JWTService
+     * @see JwtService
      * @see AuthenticationController
      *
      * @param request a SignInUserRequest representing the JSON request
      * @return a UserJWTDetails object based on the user with the email
      * @throws UserNotFoundException if the user with the email is not found
      */
-    public final UserJWTDetails verifyUserSignIn(SignInUserRequest request) throws UserNotFoundException, IncorrectSignInException {
+    public final UserJwtDetails verifyUserSignIn(SignInUserRequest request) throws UserNotFoundException, IncorrectSignInException {
         User user = userRepository.findByEmail(request.getEmail()).orElseThrow(UserNotFoundException::new);
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPasswordHash().toString())) {
             throw new IncorrectSignInException();
         }
 
-        return new UserJWTDetails(user);
+        return new UserJwtDetails(user);
     }
 
     /**
@@ -110,7 +112,7 @@ public class UserService {
      * @param request a RegisterUserRequest representing the JSON request
      * @return a UserJWTDetails object used to generate an access token
      */
-    public final UserJWTDetails createUser(RegisterUserRequest request) throws UserAlreadyExistsException {
+    public final UserJwtDetails createUser(RegisterUserRequest request) throws UserAlreadyExistsException {
 
         Optional<User> existingUser = userRepository.findByEmail(request.getEmail());
         if (existingUser.isPresent()) throw new UserAlreadyExistsException();
@@ -122,7 +124,7 @@ public class UserService {
         newUser.setPasswordHash(hash);
         userRepository.save(newUser);
 
-        return new UserJWTDetails(newUser);
+        return new UserJwtDetails(newUser);
     }
 
     /**

--- a/spring/src/test/java/com/focust/api/controllers/UserIntegrationTests.java
+++ b/spring/src/test/java/com/focust/api/controllers/UserIntegrationTests.java
@@ -25,7 +25,7 @@
  * @see com.focust.api.controllers.UserController
  *
  * @author Allan DeBoe (allan.m.deboe@gmail.com)
- * @version 0.0.3
+ * @version 0.0.4
  * @since 0.0.3
  */
 package com.focust.api.controllers;
@@ -80,12 +80,12 @@ class UserIntegrationTests {
     public final void givenAuthRegister_whenSendingRequest_thenCreatedStatus() {
         RegisterUserRequest request = new RegisterUserRequest("user@focust.local", "password123");
 
-        System.out.println("(UserIntegrationTests) - Sending:\n\"" + request.getJSON() + "\"");
+        System.out.println("(UserIntegrationTests) - Sending:\n\"" + request.getJson() + "\"");
 
         Response response = RestAssured.given()
                 .accept(ContentType.JSON)
                 .contentType(ContentType.JSON)
-                .body(request.getJSON())
+                .body(request.getJson())
                 .when().post("/auth/register");
 
         String responseBody = response.thenReturn().asString();
@@ -93,7 +93,10 @@ class UserIntegrationTests {
 
         response.then().assertThat()
                 .statusCode(HttpStatus.CREATED.value())
-                .body("jwtToken", isA(String.class))
+                .cookie("jwt-refresh-token", isA(String.class))
+                .and()
+                .body("accessToken", isA(String.class))
+                .and()
                 .body("userId", isA(Integer.class));
     }
 
@@ -101,12 +104,12 @@ class UserIntegrationTests {
     public final void givenAuthRegister_whenSendingRequestAndUserExists_thenOkStatus() {
         RegisterUserRequest request = new RegisterUserRequest("user@focust.local", "123456pass");
 
-        System.out.println("(UserIntegrationTests) - Sending:\n\"" + request.getJSON() + "\"");
+        System.out.println("(UserIntegrationTests) - Sending:\n\"" + request.getJson() + "\"");
 
         Response response = RestAssured.given()
                 .accept(ContentType.JSON)
                 .contentType(ContentType.JSON)
-                .body(request.getJSON())
+                .body(request.getJson())
                 .when().post("/auth/register");
 
         String responseBody = response.thenReturn().asString();
@@ -121,12 +124,12 @@ class UserIntegrationTests {
 
         SignInUserRequest request = new SignInUserRequest("user@focust.local", "password123");
 
-        System.out.println("(UserIntegrationTests) - Sending:\n\"" + request.getJSON() + "\"");
+        System.out.println("(UserIntegrationTests) - Sending:\n\"" + request.getJson() + "\"");
 
         Response response = RestAssured.given()
                 .accept(ContentType.JSON)
                 .contentType(ContentType.JSON)
-                .body(request.getJSON())
+                .body(request.getJson())
                 .when().post("/auth/login");
 
         String responseBody = response.thenReturn().asString();
@@ -134,7 +137,10 @@ class UserIntegrationTests {
 
         response.then().assertThat()
                 .statusCode(HttpStatus.OK.value())
-                .body("jwtToken", isA(String.class))
+                .cookie("jwt-refresh-token", isA(String.class))
+                .and()
+                .body("accessToken", isA(String.class))
+                .and()
                 .body("userId", isA(Integer.class));
 
     }
@@ -144,12 +150,12 @@ class UserIntegrationTests {
 
         SignInUserRequest request = new SignInUserRequest("user@focust.local", "123456pass");
 
-        System.out.println("(UserIntegrationTests) - Sending:\n\"" + request.getJSON() + "\"");
+        System.out.println("(UserIntegrationTests) - Sending:\n\"" + request.getJson() + "\"");
 
         Response response = RestAssured.given()
                 .accept(ContentType.JSON)
                 .contentType(ContentType.JSON)
-                .body(request.getJSON())
+                .body(request.getJson())
                 .when().post("/auth/login");
 
         String responseBody = response.thenReturn().asString();
@@ -165,12 +171,12 @@ class UserIntegrationTests {
 
         SignInUserRequest request = new SignInUserRequest("test@focust.local", "123456pass");
 
-        System.out.println("(UserIntegrationTests) - Sending:\n\"" + request.getJSON() + "\"");
+        System.out.println("(UserIntegrationTests) - Sending:\n\"" + request.getJson() + "\"");
 
         Response response = RestAssured.given()
                 .accept(ContentType.JSON)
                 .contentType(ContentType.JSON)
-                .body(request.getJSON())
+                .body(request.getJson())
                 .when().post("/auth/login");
 
         String responseBody = response.thenReturn().asString();
@@ -185,12 +191,12 @@ class UserIntegrationTests {
     public final void givenUsers_whenSendingRequestForUsers_thenOkStatus() {
 
         PageNumberRequest request = new PageNumberRequest();
-        System.out.println("(UserIntegrationTests) - Sending:\n\"" + request.getJSON() + "\"");
+        System.out.println("(UserIntegrationTests) - Sending:\n\"" + request.getJson() + "\"");
 
         Response response = RestAssured.given()
                 .accept(ContentType.JSON)
                 .contentType(ContentType.JSON)
-                .body(request.getJSON())
+                .body(request.getJson())
                 .when().get("/users");
 
         String responseBody = response.thenReturn().asString();


### PR DESCRIPTION
For this commit, I simply included a new function for the `JWTService` class (renamed to `JwtService`) to generate refresh tokens, which will be used to allow one to not have to sign in every 5 minutes while also keeping the expiration date for access tokens short for security reasons. The refresh tokens are made to last 1 week (7 days).

I also updated the `README.md` to make it more clear on the most important dependencies for both the back-end and front-end servers, plus more general dependencies like Docker and Jenkins. Regarding the `./spring/README.md` file, I simply changed "**JUnit**" to "**JUnit 5**", as JUnit 5 is used for the tests.